### PR TITLE
Ajout de la chaine welovedevs.com

### DIFF
--- a/json/devweb.json
+++ b/json/devweb.json
@@ -327,5 +327,12 @@
     "frameworks": ["svelte","sapper","nodejs","tailwindcss","mocha","chai"],
     "outils": ["vscode","github","vercel","GCP"],
     "autre": ["devlog","clean architecture","tdd","approche produit","clean code","product management","design","UX","UI","architecture logicielle"]
-}
+  },
+  {
+    "url": "https://www.youtube.com/channel/UCUZcVUeCtPbcsPGMU6icxUQ",
+    "langages": ["react", "typescript", "node"],
+    "frameworks": [],
+    "outils": ["github"],
+    "autre": ["recrutement", "jobs", "open-source", "développement personnel"]
+  }
 ]


### PR DESCRIPTION
Hello !

Merci pour ce super travail de référencement des chaines youtubes pour développeurs, j'ai installé et lancé le projet en local sans soucis.
Voici une PR pour ajouter la chaine youtube de welovedevs.

Le résultat : 
<img width="1429" alt="Screenshot 2021-08-18 at 19 11 50" src="https://user-images.githubusercontent.com/9655206/129924578-c86c6068-10c9-4801-b380-42aa8861fe4f.png">
