### PR TITLE
Ajout de we want code (fr)

### DIFF
--- a/json/devweb.json
+++ b/json/devweb.json
@@ -348,5 +348,6 @@
     "frameworks": ["laravel", "tailwindcss", "vue"],
     "outils": ["phpstorm", "vscode", "wordpress"],
     "autre": ["formation", "bonnes pratiques", "conseils & astuces"]
-  }
+  },
+  {"url": "https://www.youtube.com/channel/UCMLVr2Jb92Uu53ujFyq8tBQ", "langages": ["html", "css", "javascript", "python"], "frameworks": ["react", "angular", "ionic"], "outils": ["git", "docker", "gitlab"], "autre": ["formation"]}
 ]


### PR DESCRIPTION
Chaîne française wewantcode.com : tutoriels web HTML/CSS/JS/Python + React/Angular/Ionic, avec git/docker/gitlab.